### PR TITLE
fix: inline permissions check and simplify pr-preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -6,8 +6,40 @@ on:
 
 jobs:
   check-permissions:
-    uses: patternfly/.github/.github/workflows/check-team-membership.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/deploy-preview'))
+    outputs:
+      allowed: ${{ steps.check-team.outputs.allowed }}
+      pr-number: ${{ steps.check-team.outputs.number }}
+    steps:
+      - name: Get PR info and check permissions
+        id: check-team
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          COMMENT_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            ASSOCIATION="$PR_ASSOCIATION"
+          else
+            echo "number=$COMMENT_NUMBER" >> $GITHUB_OUTPUT
+            ASSOCIATION="$COMMENT_ASSOCIATION"
+          fi
+
+          if [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || "$ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            echo "User is a repo $ASSOCIATION — allowed"
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+            echo "User association is $ASSOCIATION — not allowed"
+          fi
 
   deploy-preview:
     runs-on: ubuntu-latest
@@ -20,15 +52,9 @@ jobs:
       GH_PR_NUM: ${{ needs.check-permissions.outputs.pr-number }}
     steps:
       - uses: actions/checkout@v4
-      # Checkout the PR branch
       - run: |
           git fetch origin pull/$GH_PR_NUM/head:tmp
           git checkout tmp
-      - run: |
-          git rev-parse origin/main
-          git rev-parse HEAD
-          git rev-parse origin/main..HEAD
-          git log origin/main..HEAD --format="%b"
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -40,28 +66,14 @@ jobs:
           path: |
             node_modules
             **/node_modules
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-22-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - run: yarn build
         name: Build
-      - uses: actions/cache@v4
-        id: docs-cache
-        name: Load webpack cache
-        with:
-          path: '.cache'
-          key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
       - run: yarn build:docs
         name: Build docs
       - name: Upload docs
         uses: patternfly/.github/.github/actions/surge-preview@main
-        if: always()
         with:
           folder: packages/module/public
-      - run: yarn serve:docs & yarn test:a11y
-        name: a11y tests
-      - name: Upload a11y report
-        uses: patternfly/.github/.github/actions/surge-preview@main
-        if: always()
-        with:
-          folder: packages/module/coverage


### PR DESCRIPTION
Replace reusable patternfly/.github workflow with inlined permissions check for compatibility with the dashboard fork. Remove a11y tests, webpack cache, and debug steps already covered by check-pr.yml.